### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-IrData			KEYWORD1
-IrReciver		KEYWORD1
+IrData	KEYWORD1
+IrReciver	KEYWORD1
 IrTransmitter	KEYWORD1
 
 #######################################
@@ -26,10 +26,10 @@ sendMitsubishi KEYWORD2
 sendRaw	KEYWORD2
 sendRc5	KEYWORD2
 sendRc6	KEYWORD2
-sendDish KEYWORD2
-sendSharp KEYWORD2
-sendPanasonic KEYWORD2
-sendJvc KEYWORD2
+sendDish	KEYWORD2
+sendSharp	KEYWORD2
+sendPanasonic	KEYWORD2
+sendJvc	KEYWORD2
 
 #
 #######################################
@@ -42,9 +42,9 @@ SANYO LITERAL1
 MITSUBISHI LITERAL1
 RC5	LITERAL1
 RC6	LITERAL1
-DISH LITERAL1
-SHARP LITERAL1
-PANASONIC LITERAL1
-JVC LITERAL1
+DISH	LITERAL1
+SHARP	LITERAL1
+PANASONIC	LITERAL1
+JVC	LITERAL1
 UNKNOWN	LITERAL1
 REPEAT	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords